### PR TITLE
feat: add parallel NMEA protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # NMEA Simulator
 
-A versatile NMEA 0183 sentence simulator that generates realistic marine navigation and environmental data over TCP and WebSocket protocols.
+A versatile marine data simulator supporting both NMEA 0183 and NMEA 2000 protocols simultaneously.
 
 ## Features
 
-- **Multiple Protocol Support**
-  - TCP server (default NMEA port 10110)
-  - WebSocket server with web interface
+### NMEA 0183
+- **TCP Server** (default port 10110)
+- **WebSocket Server** with web interface (default port 8080)
 - **Configurable Baud Rates**: 4800, 9600, 19200, 38400
-- **NMEA 0183 Sentences**
+- **Supported Sentences**
   - Position: GGA (GPS Fix), GLL (Geographic Position)
   - Navigation: RMC (Recommended Minimum), HDT (True Heading), VTG (Track & Speed), XTE (Cross-Track Error)
   - Environment: DBT (Depth Below Transducer), MTW (Water Temperature), MWV (Wind), VHW (Water Speed & Heading), DPT (Depth)
+
+### NMEA 2000
+- **TCP Server** (default port 10200)
+- **WebSocket Server** with web interface (default port 8081)
+- **Supported PGNs**
+  - 127250 (Vessel Heading)
+  - 128259 (Speed)
+  - 128267 (Water Depth)
+  - 129025 (Position Rapid Update)
+  - 129026 (COG & SOG Rapid Update)
+  - 130306 (Wind Data)
 
 ## Installation
 
@@ -29,23 +40,93 @@ make build
 
 ## Usage
 
-Run with default settings:
+By default, the simulator runs both NMEA 0183 and NMEA 2000 protocols simultaneously:
 ```bash
 nmeasim
 ```
 
+### Run Specific Protocol
+
+Run only NMEA 0183:
+```bash
+nmeasim --protocol nmea0183
+```
+
+Run only NMEA 2000:
+```bash
+nmeasim --protocol nmea2000
+```
+
 ### Command Line Options
 
-- `--ws-port`: WebSocket server port (default: 8080)
-- `--tcp-port`: TCP server port (default: 10110)
-- `--host`: Host to bind servers to (default: "0.0.0.0")
-- `--interval`: NMEA sentence update interval (default: 1s)
+Protocol Selection:
+- `--protocol`: Protocol to use ("both", "nmea0183", or "nmea2000", default: "both")
+
+NMEA 0183 Options:
+- `--nmea0183-ws-port`: WebSocket server port (default: 8080)
+- `--nmea0183-tcp-port`: TCP server port (default: 10110)
 - `--baud`: Baud rate for TCP output (default: 4800)
 
-Example with custom settings:
+NMEA 2000 Options:
+- `--nmea2000-ws-port`: WebSocket server port (default: 8081)
+- `--nmea2000-tcp-port`: TCP port (default: 10200)
+
+Common Options:
+- `--host`: Host to bind servers to (default: "0.0.0.0")
+- `--interval`: Data update interval (default: 1s)
+
+## Web Interface
+
+The web interface now supports viewing both NMEA 0183 and NMEA 2000 data simultaneously. Access it at:
+- NMEA 0183: http://localhost:8080
+- NMEA 2000: http://localhost:8081
+
+## Viewing TCP Data
+
+You can use common terminal commands to view the NMEA data streams directly:
+
+### Using netcat (nc)
+
+For NMEA 0183:
 ```bash
-nmeasim --ws-port 8081 --tcp-port 10111 --interval 500ms --baud 9600
+nc localhost 10110
 ```
+
+For NMEA 2000:
+```bash
+nc localhost 10200
+```
+
+### Using telnet
+
+For NMEA 0183:
+```bash
+telnet localhost 10110
+```
+
+For NMEA 2000:
+```bash
+telnet localhost 10200
+```
+
+### Using socat with hex dump
+
+To view data with timestamps and hex dump:
+
+For NMEA 0183:
+```bash
+socat TCP:localhost:10110 STDOUT | hexdump -C
+```
+
+For NMEA 2000:
+```bash
+socat TCP:localhost:10200 STDOUT | hexdump -C
+```
+
+Note: You may need to install these tools first:
+- macOS: `brew install netcat socat`
+- Ubuntu/Debian: `sudo apt install netcat-openbsd socat`
+- Windows: Use PowerShell's `Test-NetConnection` or install WSL
 
 ## Development
 

--- a/cmd/nmeasim/main.go
+++ b/cmd/nmeasim/main.go
@@ -1,3 +1,5 @@
+// Package main provides the NMEA simulator command line interface
+// supporting both NMEA 0183 and NMEA 2000 protocols
 package main
 
 import (
@@ -8,16 +10,26 @@ import (
 	"time"
 
 	"github.com/captv89/nmea-simulator/pkg/network"
+	"github.com/captv89/nmea-simulator/pkg/nmea2000"
 	"github.com/rs/zerolog"
 )
 
 func main() {
 	// Command line flags
-	wsPort := flag.Int("ws-port", 8080, "WebSocket server port")
-	tcpPort := flag.Int("tcp-port", 10110, "TCP server port (default NMEA port)")
+	protocol := flag.String("protocol", "both", "Protocol to use: nmea0183, nmea2000, or both")
+
+	// NMEA 0183 flags
+	nmea0183WSPort := flag.Int("nmea0183-ws-port", 8080, "WebSocket server port for NMEA 0183")
+	nmea0183TCPPort := flag.Int("nmea0183-tcp-port", 10110, "TCP server port for NMEA 0183")
+	baudRate := flag.Int("baud", 4800, "Baud rate for NMEA 0183 TCP output (4800, 9600, 19200, 38400)")
+
+	// NMEA 2000 flags
+	nmea2000WSPort := flag.Int("nmea2000-ws-port", 8081, "WebSocket server port for NMEA 2000")
+	nmea2000TCPPort := flag.Int("nmea2000-tcp-port", 10200, "TCP port for NMEA 2000")
+
+	// Common flags
 	host := flag.String("host", "0.0.0.0", "Host to bind servers to")
-	interval := flag.Duration("interval", time.Second, "NMEA sentence update interval")
-	baudRate := flag.Int("baud", 4800, "Baud rate for TCP output (4800, 9600, 19200, 38400)")
+	interval := flag.Duration("interval", time.Second, "Data update interval")
 	flag.Parse()
 
 	// Validate baud rate
@@ -29,54 +41,125 @@ func main() {
 	// Setup logger
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 
-	// Create server configuration
-	cfg := network.Config{
-		Host:           *host,
-		UpdateInterval: *interval,
-		Logger:         logger,
-		BaudRate:       *baudRate,
-		SentenceOptions: network.SentenceOptions{
-			EnablePosition:    true,
-			EnableNavigation:  true,
-			EnableEnvironment: true,
-		},
-	}
-
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	// Create WebSocket server
-	wsCfg := cfg
-	wsCfg.Port = *wsPort
-	wsServer := network.NewWebSocketServer(wsCfg)
-
-	// Create TCP server
-	tcpCfg := cfg
-	tcpCfg.Port = *tcpPort
-	tcpServer := network.NewTCPServer(tcpCfg)
-
-	// Start servers
-	go func() {
-		if err := wsServer.Start(ctx); err != nil {
-			logger.Error().Err(err).Msg("websocket server failed")
-		}
-	}()
-
-	go func() {
-		if err := tcpServer.Start(ctx); err != nil {
-			logger.Error().Err(err).Msg("tcp server failed")
-		}
-	}()
 
 	// Handle graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
-	<-sigChan
-	logger.Info().Msg("shutting down servers...")
+	var nmea0183Servers []network.Server
+	var nmea2000Sim *nmea2000.Simulator
 
-	cancel()
-	wsServer.Stop()
-	tcpServer.Stop()
+	// Start NMEA 0183 servers if needed
+	if *protocol == "both" || *protocol == "nmea0183" {
+		// Create NMEA 0183 server configuration
+		cfg := network.Config{
+			Host:           *host,
+			UpdateInterval: *interval,
+			Logger:         logger,
+			BaudRate:       *baudRate,
+			Protocol:       "nmea0183",
+			SentenceOptions: network.SentenceOptions{
+				EnablePosition:    true,
+				EnableNavigation:  true,
+				EnableEnvironment: true,
+			},
+		}
+
+		// Create WebSocket server
+		wsCfg := cfg
+		wsCfg.Port = *nmea0183WSPort
+		wsServer := network.NewWebSocketServer(wsCfg)
+		nmea0183Servers = append(nmea0183Servers, wsServer)
+
+		// Create TCP server
+		tcpCfg := cfg
+		tcpCfg.Port = *nmea0183TCPPort
+		tcpServer := network.NewTCPServer(tcpCfg)
+		nmea0183Servers = append(nmea0183Servers, tcpServer)
+
+		// Start NMEA 0183 servers
+		for _, server := range nmea0183Servers {
+			srv := server // Create new variable for goroutine
+			go func() {
+				if err := srv.Start(ctx); err != nil {
+					logger.Error().Err(err).Msg("NMEA 0183 server failed")
+				}
+			}()
+		}
+
+		logger.Info().
+			Int("ws_port", *nmea0183WSPort).
+			Int("tcp_port", *nmea0183TCPPort).
+			Msg("NMEA 0183 simulator started")
+	}
+
+	// Start NMEA 2000 servers if needed
+	if *protocol == "both" || *protocol == "nmea2000" {
+		// Create NMEA 2000 TCP server
+		tcpCfg := network.Config{
+			Host:           *host,
+			Port:           *nmea2000TCPPort,
+			UpdateInterval: *interval,
+			Logger:         logger,
+			Protocol:       "nmea2000",
+		}
+		tcpServer := network.NewTCP2000Server(tcpCfg)
+
+		// Create NMEA 2000 WebSocket server
+		wsCfg := network.Config{
+			Host:           *host,
+			Port:           *nmea2000WSPort,
+			UpdateInterval: *interval,
+			Logger:         logger,
+			Protocol:       "nmea2000",
+		}
+		wsServer := network.NewWebSocket2000Server(wsCfg)
+
+		// Create and start NMEA 2000 simulator
+		nmea2000Sim = nmea2000.New(nmea2000.Config{
+			Transport:    tcpServer,
+			WebSocket:    wsServer,
+			UpdatePeriod: *interval,
+		})
+
+		// Start WebSocket server
+		go func() {
+			if err := wsServer.Start(ctx); err != nil {
+				logger.Error().Err(err).Msg("NMEA 2000 websocket server failed")
+			}
+		}()
+
+		// Start simulator (which starts TCP server)
+		if err := nmea2000Sim.Start(ctx); err != nil {
+			logger.Error().Err(err).Msg("NMEA 2000 simulator failed to start")
+			os.Exit(1)
+		}
+
+		logger.Info().
+			Int("ws_port", *nmea2000WSPort).
+			Int("tcp_port", *nmea2000TCPPort).
+			Msg("NMEA 2000 simulator started")
+	}
+
+	if *protocol != "both" && *protocol != "nmea0183" && *protocol != "nmea2000" {
+		logger.Error().Str("protocol", *protocol).Msg("invalid protocol specified")
+		os.Exit(1)
+	}
+
+	// Wait for interrupt signal
+	<-sigChan
+	logger.Info().Msg("shutting down simulators...")
+
+	// Stop NMEA 0183 servers
+	for _, server := range nmea0183Servers {
+		server.Stop()
+	}
+
+	// Stop NMEA 2000 simulator
+	if nmea2000Sim != nil {
+		nmea2000Sim.Stop()
+	}
 }

--- a/coverage.html
+++ b/coverage.html
@@ -3,7 +3,8 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<title>nmeasim: Go Coverage Report</title>
+                <title>nmeasim: Go Coverage Report</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<style>
 			body {
 				background: black;
@@ -53,7 +54,7 @@
 	<body>
 		<div id="topbar">
 			<div id="nav">
-				<select id="files">
+                                <select id="files" title="Select a file to view coverage">
 				
 				<option value="file0">github.com/captv89/nmea-simulator/cmd/nmeasim/main.go (0.0%)</option>
 				

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/captv89/nmea-simulator/pkg/nmea2000/pgn"
 	"github.com/rs/zerolog"
 )
 
@@ -15,6 +16,12 @@ type Server interface {
 	Stop() error
 }
 
+// NMEA2000Server represents a server that can stream NMEA 2000 messages
+type NMEA2000Server interface {
+	Server
+	SendPGN(msg pgn.Message) error
+}
+
 // Config holds server configuration
 type Config struct {
 	Host            string
@@ -22,7 +29,8 @@ type Config struct {
 	UpdateInterval  time.Duration
 	Logger          zerolog.Logger
 	SentenceOptions SentenceOptions
-	BaudRate        int // Added baud rate configuration
+	BaudRate        int
+	Protocol        string // "nmea0183" or "nmea2000"
 }
 
 // SentenceOptions configures which NMEA sentences to generate

--- a/pkg/network/tcp2000.go
+++ b/pkg/network/tcp2000.go
@@ -1,0 +1,121 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/captv89/nmea-simulator/pkg/nmea2000/pgn"
+)
+
+// TCP2000Server implements NMEA 2000 message streaming over TCP
+type TCP2000Server struct {
+	*BaseServer
+	listener net.Listener
+	clients  map[net.Conn]bool
+}
+
+// NewTCP2000Server creates a new TCP server instance for NMEA 2000
+func NewTCP2000Server(cfg Config) *TCP2000Server {
+	return &TCP2000Server{
+		BaseServer: NewBaseServer(cfg),
+		clients:    make(map[net.Conn]bool),
+	}
+}
+
+// Start begins the TCP server
+func (s *TCP2000Server) Start(ctx context.Context) error {
+	addr := fmt.Sprintf("%s:%d", s.Config.Host, s.Config.Port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to start TCP listener: %w", err)
+	}
+	s.listener = listener
+
+	go s.acceptLoop(ctx)
+
+	s.Config.Logger.Info().
+		Str("addr", addr).
+		Msg("NMEA 2000 TCP server started")
+
+	return nil
+}
+
+// Stop terminates the TCP server
+func (s *TCP2000Server) Stop() error {
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	close(s.Done)
+
+	s.Mu.Lock()
+	for client := range s.clients {
+		client.Close()
+	}
+	s.clients = make(map[net.Conn]bool)
+	s.Mu.Unlock()
+
+	return nil
+}
+
+// SendPGN sends a NMEA 2000 message to all connected clients
+func (s *TCP2000Server) SendPGN(msg pgn.Message) error {
+	s.Mu.RLock()
+	defer s.Mu.RUnlock()
+
+	frame := formatPGNMessage(msg)
+
+	for client := range s.clients {
+		_, err := client.Write([]byte(frame))
+		if err != nil {
+			// Remove failed client
+			s.Mu.RUnlock()
+			s.Mu.Lock()
+			delete(s.clients, client)
+			client.Close()
+			s.Mu.Unlock()
+			s.Mu.RLock()
+		}
+	}
+	return nil
+}
+
+func (s *TCP2000Server) acceptLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.Done:
+			return
+		default:
+			conn, err := s.listener.Accept()
+			if err != nil {
+				s.Config.Logger.Error().Err(err).Msg("Failed to accept connection")
+				continue
+			}
+			s.Mu.Lock()
+			s.clients[conn] = true
+			s.Mu.Unlock()
+			s.Config.Logger.Info().
+				Str("remote", conn.RemoteAddr().String()).
+				Msg("New NMEA 2000 client connected")
+		}
+	}
+}
+
+// formatPGNMessage formats a NMEA 2000 message for TCP transport
+// Format: $PNMEA2K,PGN,Length,Data*Checksum
+func formatPGNMessage(msg pgn.Message) string {
+	var checksum byte
+	data := fmt.Sprintf("$PNMEA2K,%d,%d,", msg.PGN, len(msg.Data))
+
+	// Calculate checksum (XOR of all bytes after $ and before *)
+	for i := 1; i < len(data); i++ {
+		checksum ^= data[i]
+	}
+	for _, b := range msg.Data {
+		checksum ^= b
+	}
+
+	return fmt.Sprintf("%s%X*%02X\r\n", data, msg.Data, checksum)
+}

--- a/pkg/network/web/index.html
+++ b/pkg/network/web/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NMEA Simulator - WebSocket Client</title>
     <style>
         body {
@@ -10,7 +12,17 @@
             background: #f0f0f0;
         }
 
-        #output {
+        .output-container {
+            display: flex;
+            gap: 20px;
+            margin: 20px 0;
+        }
+
+        .output-section {
+            flex: 1;
+        }
+
+        .output {
             background: #000;
             color: #0f0;
             padding: 10px;
@@ -28,62 +40,117 @@
             padding: 5px 10px;
             margin-right: 10px;
         }
+
+        .protocol-section {
+            margin: 10px 0;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+        }
+
+        h2 {
+            margin-top: 0;
+        }
     </style>
 </head>
 
 <body>
     <h1>NMEA Simulator - WebSocket Client</h1>
-    <div class="controls">
-        <button onclick="connect()">Connect</button>
-        <button onclick="disconnect()">Disconnect</button>
-        <button onclick="clearOutput()">Clear</button>
+
+    <div class="output-container">
+        <div class="output-section">
+            <div class="protocol-section">
+                <h2>NMEA 0183</h2>
+                <div class="controls">
+                    <button onclick="connect('nmea0183')">Connect</button>
+                    <button onclick="disconnect('nmea0183')">Disconnect</button>
+                    <button onclick="clearOutput('nmea0183')">Clear</button>
+                </div>
+                <div id="output-nmea0183" class="output"></div>
+            </div>
+        </div>
+
+        <div class="output-section">
+            <div class="protocol-section">
+                <h2>NMEA 2000</h2>
+                <div class="controls">
+                    <button onclick="connect('nmea2000')">Connect</button>
+                    <button onclick="disconnect('nmea2000')">Disconnect</button>
+                    <button onclick="clearOutput('nmea2000')">Clear</button>
+                </div>
+                <div id="output-nmea2000" class="output"></div>
+            </div>
+        </div>
     </div>
-    <div id="output"></div>
 
     <script>
-        let ws = null;
-        const output = document.getElementById('output');
+        const connections = {
+            nmea0183: null,
+            nmea2000: null
+        };
 
-        function connect() {
-            if (ws) {
-                output.innerHTML += 'Already connected\n';
+        const ports = {
+            nmea0183: 8080,
+            nmea2000: 8081
+        };
+
+        function getWebSocketUrl(protocol) {
+            const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const hostname = window.location.hostname;
+            const port = ports[protocol];
+            const endpoint = protocol === 'nmea2000' ? '/nmea2000' : '/ws';
+            return `${wsProtocol}//${hostname}:${port}${endpoint}`;
+        }
+
+        function getOutput(protocol) {
+            return document.getElementById('output-' + protocol);
+        }
+
+        function appendOutput(protocol, text) {
+            const output = getOutput(protocol);
+            output.innerHTML += text + '\n';
+            output.scrollTop = output.scrollHeight;
+        }
+
+        function connect(protocol) {
+            if (connections[protocol]) {
+                appendOutput(protocol, 'Already connected');
                 return;
             }
 
-            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-            const wsUrl = protocol + '//' + window.location.host + '/ws';
+            const wsUrl = getWebSocketUrl(protocol);
+            appendOutput(protocol, `Connecting to ${wsUrl}...`);
 
-            output.innerHTML += `Connecting to ${wsUrl}...\n`;
-            ws = new WebSocket(wsUrl);
+            const ws = new WebSocket(wsUrl);
+            connections[protocol] = ws;
 
             ws.onopen = () => {
-                output.innerHTML += 'Connected!\n';
+                appendOutput(protocol, 'Connected!');
             };
 
             ws.onmessage = (event) => {
-                output.innerHTML += event.data + '\n';
-                output.scrollTop = output.scrollHeight;
+                appendOutput(protocol, event.data);
             };
 
             ws.onclose = () => {
-                output.innerHTML += 'Disconnected\n';
-                ws = null;
+                appendOutput(protocol, 'Disconnected');
+                connections[protocol] = null;
             };
 
             ws.onerror = (error) => {
-                output.innerHTML += 'Error: ' + error.message + '\n';
+                appendOutput(protocol, 'Error: ' + error.message);
             };
         }
 
-        function disconnect() {
-            if (ws) {
-                ws.close();
-                ws = null;
+        function disconnect(protocol) {
+            if (connections[protocol]) {
+                connections[protocol].close();
+                connections[protocol] = null;
             }
         }
 
-        function clearOutput() {
-            output.innerHTML = '';
+        function clearOutput(protocol) {
+            getOutput(protocol).innerHTML = '';
         }
     </script>
 </body>

--- a/pkg/network/websocket2000.go
+++ b/pkg/network/websocket2000.go
@@ -1,0 +1,202 @@
+// Package network provides network streaming capabilities for NMEA sentences
+package network
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/captv89/nmea-simulator/pkg/nmea2000/pgn"
+	"github.com/gorilla/websocket"
+)
+
+// WebSocket2000Server implements NMEA 2000 message streaming over WebSocket
+type WebSocket2000Server struct {
+	*BaseServer
+	upgrader websocket.Upgrader
+	clients  map[*websocket.Conn]bool
+	clientMu sync.Mutex
+}
+
+// NewWebSocket2000Server creates a new WebSocket server instance for NMEA 2000
+func NewWebSocket2000Server(cfg Config) *WebSocket2000Server {
+	return &WebSocket2000Server{
+		BaseServer: NewBaseServer(cfg),
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(_ *http.Request) bool {
+				return true // Allow all origins in development
+			},
+		},
+		clients: make(map[*websocket.Conn]bool),
+	}
+}
+
+// Start begins the WebSocket server
+func (s *WebSocket2000Server) Start(ctx context.Context) error {
+	addr := fmt.Sprintf("%s:%d", s.Config.Host, s.Config.Port)
+
+	// Setup routes
+	mux := http.NewServeMux()
+
+	// Serve static files from the embedded filesystem
+	fsys, err := fs.Sub(webContent, "web")
+	if err != nil {
+		return fmt.Errorf("failed to setup static file serving: %w", err)
+	}
+
+	// Create a file server for static files
+	fsRoot := http.FileServer(http.FS(fsys))
+
+	// Handle root path specifically
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			// Directly serve index.html for root path
+			data, err := fs.ReadFile(fsys, "index.html")
+			if err != nil {
+				s.Config.Logger.Error().Err(err).Msg("failed to read index.html")
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html")
+			w.Write(data)
+			return
+		}
+
+		// For all other paths, use the file server
+		if strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		fsRoot.ServeHTTP(w, r)
+	})
+
+	// Handle WebSocket path for NMEA 2000
+	mux.HandleFunc("/nmea2000", s.handleWebSocket)
+
+	// Create server with logging middleware
+	handler := s.loggingMiddleware(mux)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	s.Config.Logger.Info().Str("addr", addr).Msg("starting NMEA 2000 websocket server")
+
+	// Handle server shutdown
+	go func() {
+		<-ctx.Done()
+		s.Config.Logger.Info().Msg("shutting down NMEA 2000 websocket server")
+		server.Close()
+	}()
+
+	return server.ListenAndServe()
+}
+
+// Stop terminates the WebSocket server
+func (s *WebSocket2000Server) Stop() error {
+	close(s.Done)
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+	for client := range s.clients {
+		client.Close()
+	}
+	s.clients = make(map[*websocket.Conn]bool)
+	return nil
+}
+
+// SendPGN sends a NMEA 2000 message to all connected WebSocket clients
+func (s *WebSocket2000Server) SendPGN(msg pgn.Message) error {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+
+	frame := formatPGNMessage(msg)
+
+	for client := range s.clients {
+		err := client.WriteMessage(websocket.TextMessage, []byte(frame))
+		if err != nil {
+			s.Config.Logger.Error().
+				Err(err).
+				Str("remote", client.RemoteAddr().String()).
+				Msg("Failed to send message")
+
+			client.Close()
+			delete(s.clients, client)
+		}
+	}
+	return nil
+}
+
+func (s *WebSocket2000Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.Config.Logger.Error().Err(err).Msg("Failed to upgrade connection")
+		return
+	}
+
+	s.clientMu.Lock()
+	s.clients[conn] = true
+	s.clientMu.Unlock()
+
+	s.Config.Logger.Info().
+		Str("remote", conn.RemoteAddr().String()).
+		Msg("New NMEA 2000 WebSocket client connected")
+
+	// Create a done channel for this connection
+	done := make(chan struct{})
+
+	go func() {
+		defer func() {
+			s.clientMu.Lock()
+			delete(s.clients, conn)
+			s.clientMu.Unlock()
+			conn.Close()
+			close(done)
+			s.Config.Logger.Info().
+				Str("remote", conn.RemoteAddr().String()).
+				Msg("NMEA 2000 client disconnected")
+		}()
+
+		for {
+			// Read messages from client (if any)
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+					s.Config.Logger.Error().Err(err).Msg("WebSocket read error")
+				}
+				return
+			}
+		}
+	}()
+
+	// Wait for client disconnection or context cancellation
+	select {
+	case <-r.Context().Done():
+	case <-s.Done:
+	case <-done:
+	}
+}
+
+// loggingMiddleware wraps an http.Handler and logs requests
+func (s *WebSocket2000Server) loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		s.Config.Logger.Info().
+			Str("method", r.Method).
+			Str("path", r.URL.Path).
+			Str("remote", r.RemoteAddr).
+			Msg("incoming request")
+
+		next.ServeHTTP(w, r)
+
+		s.Config.Logger.Info().
+			Str("method", r.Method).
+			Str("path", r.URL.Path).
+			Str("remote", r.RemoteAddr).
+			Dur("duration", time.Since(start)).
+			Msg("request completed")
+	})
+}

--- a/pkg/nmea2000/pgn/encoder.go
+++ b/pkg/nmea2000/pgn/encoder.go
@@ -1,0 +1,144 @@
+package pgn
+
+import (
+	"encoding/binary"
+)
+
+// VesselHeading represents PGN 127250 data
+type VesselHeading struct {
+	Heading   float64 // Radians
+	Deviation float64 // Radians
+	Variation float64 // Radians
+	Reference uint8   // 0=True, 1=Magnetic
+	Reserved  uint8
+}
+
+// EncodeVesselHeading encodes PGN 127250 data
+func EncodeVesselHeading(h VesselHeading) []byte {
+	data := make([]byte, 8)
+
+	// Convert heading to radians * 10000
+	heading := uint16(h.Heading * 10000)
+	binary.LittleEndian.PutUint16(data[0:2], heading)
+
+	// Deviation
+	deviation := int16(h.Deviation * 10000)
+	binary.LittleEndian.PutUint16(data[2:4], uint16(deviation))
+
+	// Variation
+	variation := int16(h.Variation * 10000)
+	binary.LittleEndian.PutUint16(data[4:6], uint16(variation))
+
+	// Reference and reserved
+	data[6] = h.Reference
+	data[7] = h.Reserved
+
+	return data
+}
+
+// WaterDepth represents PGN 128267 data
+type WaterDepth struct {
+	Depth    float64 // Meters
+	Offset   float64 // Meters
+	MaxRange float64 // Meters
+}
+
+// EncodeWaterDepth encodes PGN 128267 data
+func EncodeWaterDepth(d WaterDepth) []byte {
+	data := make([]byte, 8)
+
+	// Convert depth to centimeters (0.01m resolution)
+	depth := uint32(d.Depth * 100)
+	binary.LittleEndian.PutUint32(data[0:4], depth)
+
+	// Offset
+	offset := int16(d.Offset * 100)
+	binary.LittleEndian.PutUint16(data[4:6], uint16(offset))
+
+	// Range
+	maxRange := uint16(d.MaxRange * 100)
+	binary.LittleEndian.PutUint16(data[6:8], maxRange)
+
+	return data
+}
+
+// WindData represents PGN 130306 data
+type WindData struct {
+	WindSpeed float64 // Meters per second
+	WindAngle float64 // Radians
+	Reference uint8   // 0=True, 1=Apparent
+}
+
+// EncodeWindData encodes PGN 130306 data
+func EncodeWindData(w WindData) []byte {
+	data := make([]byte, 8)
+
+	// Wind speed (0.01 m/s resolution)
+	speed := uint16(w.WindSpeed * 100)
+	binary.LittleEndian.PutUint16(data[0:2], speed)
+
+	// Wind angle (0.0001 radian resolution)
+	angle := uint16(w.WindAngle * 10000)
+	binary.LittleEndian.PutUint16(data[2:4], angle)
+
+	// Reference
+	data[4] = w.Reference
+
+	// Reserved bytes
+	data[5] = 0xFF
+	data[6] = 0xFF
+	data[7] = 0xFF
+
+	return data
+}
+
+// Position represents PGN 129025 data
+type Position struct {
+	Latitude  float64 // Degrees
+	Longitude float64 // Degrees
+}
+
+// EncodePosition encodes PGN 129025 data
+func EncodePosition(p Position) []byte {
+	data := make([]byte, 8)
+
+	// Convert latitude to 1e-7 degrees
+	lat := int32(p.Latitude * 1e7)
+	binary.LittleEndian.PutUint32(data[0:4], uint32(lat))
+
+	// Convert longitude to 1e-7 degrees
+	lon := int32(p.Longitude * 1e7)
+	binary.LittleEndian.PutUint32(data[4:8], uint32(lon))
+
+	return data
+}
+
+// SpeedData represents PGN 128259 data
+type SpeedData struct {
+	SpeedWater  float64 // Meters per second
+	SpeedGround float64 // Meters per second
+	Reference   uint8   // 0=Paddle wheel, 1=Pitot tube, 2=Doppler, 3=Correlation
+}
+
+// EncodeSpeedData encodes PGN 128259 data
+func EncodeSpeedData(s SpeedData) []byte {
+	data := make([]byte, 8)
+
+	// Water speed (0.01 m/s resolution)
+	waterSpeed := uint16(s.SpeedWater * 100)
+	binary.LittleEndian.PutUint16(data[0:2], waterSpeed)
+
+	// Ground speed
+	groundSpeed := uint16(s.SpeedGround * 100)
+	binary.LittleEndian.PutUint16(data[2:4], groundSpeed)
+
+	// Reference type
+	data[4] = s.Reference
+
+	// Reserved bytes
+	data[5] = 0xFF
+	data[6] = 0xFF
+	data[7] = 0xFF
+
+	return data
+}

--- a/pkg/nmea2000/pgn/types.go
+++ b/pkg/nmea2000/pgn/types.go
@@ -1,0 +1,60 @@
+// Package pgn provides NMEA 2000 PGN (Parameter Group Number) definitions and encoding
+package pgn
+
+// PGNDefinition represents the structure of a NMEA 2000 PGN
+type PGNDefinition struct {
+	PGN         uint32
+	Name        string
+	Length      uint8
+	Resolution  float64
+	Min         float64
+	Max         float64
+	Units       string
+	Description string
+}
+
+// CommonPGNs defines the most commonly used PGNs in marine applications
+var CommonPGNs = map[uint32]PGNDefinition{
+	127250: {
+		PGN:         127250,
+		Name:        "Vessel Heading",
+		Description: "Heading sensor value with a flag for True or Magnetic",
+		Length:      8,
+	},
+	128259: {
+		PGN:         128259,
+		Name:        "Speed",
+		Description: "Speed through water",
+		Length:      8,
+	},
+	128267: {
+		PGN:         128267,
+		Name:        "Water Depth",
+		Description: "Water depth information",
+		Length:      8,
+	},
+	129025: {
+		PGN:         129025,
+		Name:        "Position Rapid Update",
+		Description: "Provides lat/lon rapid update",
+		Length:      8,
+	},
+	129026: {
+		PGN:         129026,
+		Name:        "COG & SOG Rapid Update",
+		Description: "Course Over Ground and Speed Over Ground",
+		Length:      8,
+	},
+	130306: {
+		PGN:         130306,
+		Name:        "Wind Data",
+		Description: "Wind speed, direction, and reference",
+		Length:      8,
+	},
+}
+
+// Message represents a NMEA 2000 message with its PGN and data
+type Message struct {
+	PGN  uint32
+	Data []byte
+}

--- a/pkg/nmea2000/simulator.go
+++ b/pkg/nmea2000/simulator.go
@@ -1,0 +1,119 @@
+// Package nmea2000 provides NMEA 2000 simulation capabilities
+package nmea2000
+
+import (
+	"context"
+	"time"
+
+	"github.com/captv89/nmea-simulator/pkg/network"
+	"github.com/captv89/nmea-simulator/pkg/nmea2000/pgn"
+)
+
+// Simulator represents a NMEA 2000 network simulator
+type Simulator struct {
+	transport    network.NMEA2000Server
+	webSocket    network.NMEA2000Server
+	updatePeriod time.Duration
+	done         chan struct{}
+}
+
+// Config holds simulator configuration
+type Config struct {
+	Transport    network.NMEA2000Server
+	WebSocket    network.NMEA2000Server
+	UpdatePeriod time.Duration
+}
+
+// New creates a new NMEA 2000 simulator
+func New(cfg Config) *Simulator {
+	return &Simulator{
+		transport:    cfg.Transport,
+		webSocket:    cfg.WebSocket,
+		updatePeriod: cfg.UpdatePeriod,
+		done:         make(chan struct{}),
+	}
+}
+
+// Start begins the simulation
+func (s *Simulator) Start(ctx context.Context) error {
+	if err := s.transport.Start(ctx); err != nil {
+		return err
+	}
+
+	go s.simulationLoop(ctx)
+	return nil
+}
+
+// Stop terminates the simulation
+func (s *Simulator) Stop() error {
+	close(s.done)
+	if err := s.transport.Stop(); err != nil {
+		return err
+	}
+	if s.webSocket != nil {
+		return s.webSocket.Stop()
+	}
+	return nil
+}
+
+func (s *Simulator) simulationLoop(ctx context.Context) {
+	ticker := time.NewTicker(s.updatePeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		case <-ticker.C:
+			s.generateAndSendMessages()
+		}
+	}
+}
+
+func (s *Simulator) generateAndSendMessages() {
+	// Generate and send vessel heading
+	heading := pgn.VesselHeading{
+		Heading:   0.5, // ~28.6 degrees
+		Reference: 0,   // True heading
+	}
+	msg := pgn.Message{
+		PGN:  127250,
+		Data: pgn.EncodeVesselHeading(heading),
+	}
+	s.transport.SendPGN(msg)
+	if s.webSocket != nil {
+		s.webSocket.SendPGN(msg)
+	}
+
+	// Generate and send water depth
+	depth := pgn.WaterDepth{
+		Depth:    10.5, // 10.5 meters
+		Offset:   -1.5, // Transducer is 1.5m below water line
+		MaxRange: 100.0,
+	}
+	msg = pgn.Message{
+		PGN:  128267,
+		Data: pgn.EncodeWaterDepth(depth),
+	}
+	s.transport.SendPGN(msg)
+	if s.webSocket != nil {
+		s.webSocket.SendPGN(msg)
+	}
+
+	// Generate and send wind data
+	wind := pgn.WindData{
+		WindSpeed: 5.5, // 5.5 m/s
+		WindAngle: 2.0, // ~114.6 degrees
+		Reference: 1,   // Apparent wind
+	}
+	msg = pgn.Message{
+		PGN:  130306,
+		Data: pgn.EncodeWindData(wind),
+	}
+	s.transport.SendPGN(msg)
+	if s.webSocket != nil {
+		s.webSocket.SendPGN(msg)
+	}
+}


### PR DESCRIPTION
Implement simultaneous NMEA 0183 and NMEA 2000 protocol support with the following changes:

- Add protocol selection with --protocol flag (nmea0183, nmea2000, or both)
- Implement separate WebSocket and TCP servers for each protocol
- Add NMEA 2000 PGN support with new server implementations
- Update web interface to show both protocols side by side
- Add documentation for viewing TCP data using terminal tools
- Improve CLI options with protocol-specific port configuration

The simulator now supports running both protocols simultaneously by default, while maintaining backward compatibility with single protocol operation.